### PR TITLE
Updated 'i hate this' button

### DIFF
--- a/anything_but/app/controllers/recommendations_controller.rb
+++ b/anything_but/app/controllers/recommendations_controller.rb
@@ -9,7 +9,7 @@ class RecommendationsController < ApplicationController
     #takes the massive array of recommendation objects from the API and
     #creates new Recommendation instances to populate our DB with each rec
     filtered.each do |one_rec|
-      recommendation = Recommendation.create(name:one_rec.name, url: one_rec.url)
+      Recommendation.create(name:one_rec.name, url: one_rec.url)
     end
 
     #can we combine this into lines 11-13? and/or somehow have this happen
@@ -33,6 +33,12 @@ class RecommendationsController < ApplicationController
 
 
   def show
+    @recommendation=Recommendation.all.sample
+    respond_to do |f|
+      f.json {
+        render json: {name:@recommendation.name, url:@recommendation.url}
+      }
+    end
   end
 
 

--- a/anything_but/app/views/activities/_i_hate_that.html.erb
+++ b/anything_but/app/views/activities/_i_hate_that.html.erb
@@ -1,3 +1,3 @@
 <form>
-  <button type="button" id="newRec">I hate that!</button>
+  <button type="button" id="newRec">I don't want to go there!</button>
 </form>

--- a/anything_but/app/views/welcome/welcome.html.erb
+++ b/anything_but/app/views/welcome/welcome.html.erb
@@ -68,4 +68,15 @@
     })
   })
 
+  $("#dislike-button").click(function(){
+    $.ajax({
+      url: "/new-recommendation",
+      method: "GET",
+      dataType: "json",
+      success: function(newRecommendation, status){
+        $("#rec-response-h1")[0].innerHTML="<a target='_blank' href='"+newRecommendation.url+"'>"+newRecommendation.name+"</a>";
+      }
+    })
+  })
+
 </script>

--- a/anything_but/config/routes.rb
+++ b/anything_but/config/routes.rb
@@ -12,4 +12,6 @@ Rails.application.routes.draw do
   get '/signup', to: 'users#new'
   post '/users', to: 'users#create'
 
+  get '/new-recommendation', to: 'recommendations#show'
+
 end


### PR DESCRIPTION
Updated the 'i hate this button' (which now reads 'i dont want to go there', though we're not 100% on that) to load a new recommendation from the database and replace the one currently offered to hte user. This can be done over and over without making any API calls, although there is currently a chance that the user will get the same recommendation, which is a next step fix.
